### PR TITLE
Use scrypt from RustCrypto (untested)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
-rust-crypto-wasm = "^0.3"
+scrypt = { version = "0.2", default-features = false }
 hex = "^0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2"
 scrypt = { version = "0.2", default-features = false }
-hex = "^0.3"
+hex = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
-extern crate crypto;
 extern crate hex;
+extern crate scrypt;
 extern crate wasm_bindgen;
 
-use crypto::scrypt;
 use std::iter::repeat;
 use wasm_bindgen::prelude::*;
 
@@ -17,7 +16,10 @@ pub fn scrypt(password: &str, salt: &str, n: u32, r: u32, p: u32, dklen: usize) 
         return String::from("Invalid p");
     }
     let mut result: Vec<u8> = repeat(0).take(dklen).collect();
-    let params = scrypt::ScryptParams::new(log_n, r, p);
+    let params = match scrypt::ScryptParams::new(log_n, r, p) {
+        Ok(params) => params,
+        Err(_err) => return err_str,
+    };
     let pass_ = match hex::decode(password) {
         Ok(p) => p,
         Err(_err) => return err_str,
@@ -26,6 +28,6 @@ pub fn scrypt(password: &str, salt: &str, n: u32, r: u32, p: u32, dklen: usize) 
         Ok(p) => p,
         Err(_err) => return err_str,
     };
-    scrypt::scrypt(&pass_, &salt_, &params, &mut result);
+    scrypt::scrypt(&pass_, &salt_, &params, &mut result).expect("Error executing scrypt");
     hex::encode(result)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,31 +1,31 @@
-extern crate wasm_bindgen;
-extern crate hex;
 extern crate crypto;
+extern crate hex;
+extern crate wasm_bindgen;
 
-use crypto::{ scrypt };
-use wasm_bindgen::prelude::*;
+use crypto::scrypt;
 use std::iter::repeat;
+use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn scrypt(password: &str, salt: &str,  n: u32, r: u32, p: u32, dklen: usize) -> String {
-    let err_str= String::from("input Error");
+pub fn scrypt(password: &str, salt: &str, n: u32, r: u32, p: u32, dklen: usize) -> String {
+    let err_str = String::from("input Error");
     let log_n = (32 - n.leading_zeros() - 1) as u8;
     if log_n as u32 >= r * 16 {
-		return String::from("Invalid r");
-	}
-	if p as u64 > ((u32::max_value() as u64 - 1) * 32)/(128 * (r as u64)) {
-		return String::from("Invalid p");
-	}
+        return String::from("Invalid r");
+    }
+    if p as u64 > ((u32::max_value() as u64 - 1) * 32) / (128 * (r as u64)) {
+        return String::from("Invalid p");
+    }
     let mut result: Vec<u8> = repeat(0).take(dklen).collect();
-     let params = scrypt::ScryptParams::new(log_n,r,p);
-     let pass_ = match hex::decode(password){
-         Ok(p) => p,
-         Err(_err) => return err_str,
-     };
-     let salt_ = match hex::decode(salt){
-         Ok(p) => p,
-         Err(_err) => return err_str,
-     };
-     scrypt::scrypt(&pass_, &salt_, &params, &mut result);
-     hex::encode(result)
+    let params = scrypt::ScryptParams::new(log_n, r, p);
+    let pass_ = match hex::decode(password) {
+        Ok(p) => p,
+        Err(_err) => return err_str,
+    };
+    let salt_ = match hex::decode(salt) {
+        Ok(p) => p,
+        Err(_err) => return err_str,
+    };
+    scrypt::scrypt(&pass_, &salt_, &params, &mut result);
+    hex::encode(result)
 }


### PR DESCRIPTION
Based on #1

This is an attempt to use the scrypt implementation from https://github.com/RustCrypto/password-hashing, which seems to be well-maintained and remove the form rust-crypto-wasm.

I have no issues building to Wasm. This is probably because we can set `default-features = false`.

The .wasm file seems to be slightly smaller (from 38 KB to 34 KB). Note: this is a proof of concept that compiles but is otherwise untested.